### PR TITLE
Fix log messages to be consistent with HTTP method

### DIFF
--- a/index.js
+++ b/index.js
@@ -194,7 +194,7 @@ instance.prototype.action = function(action) {
 			try {
 				header = JSON.parse(action.options.header);
 			} catch(e){
-				self.log('error', 'HTTP POST Request aborted: Malformed JSON header (' + e.message+ ')');
+				self.log('error', 'HTTP GET Request aborted: Malformed JSON header (' + e.message+ ')');
 				self.status(self.STATUS_ERROR, e.message);
 				return
 			}
@@ -233,7 +233,7 @@ instance.prototype.action = function(action) {
 			try {
 				header = JSON.parse(action.options.header);
 			} catch(e){
-				self.log('error', 'HTTP POST Request aborted: Malformed JSON header (' + e.message+ ')');
+				self.log('error', 'HTTP PUT Request aborted: Malformed JSON header (' + e.message+ ')');
 				self.status(self.STATUS_ERROR, e.message);
 				return
 			}


### PR DESCRIPTION
Log messages did not have consistent HTTP method names for the type of request they were.