### PR TITLE
feat(actions): add ability to use custom variables in action options

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,11 +18,23 @@ instance.prototype.updateConfig = function (config) {
 
 	self.config = config
 
+	if (self.config.prefix !== undefined && self.config.prefix.length > 0) {
+		self.FIELD_URL.label = 'URI'
+	} else {
+		self.FIELD_URL.label = 'URL'
+	}
+
 	self.actions()
 }
 
 instance.prototype.init = function () {
 	var self = this
+	
+	if (self.config.prefix !== undefined && self.config.prefix.length > 0) {
+		self.FIELD_URL.label = 'URI'
+	} else {
+		self.FIELD_URL.label = 'URL'
+	}
 
 	self.status(self.STATE_OK)
 
@@ -80,12 +92,6 @@ instance.prototype.FIELD_HEADER = {
 
 instance.prototype.actions = function (system) {
 	var self = this
-
-	if (self.config.prefix !== undefined) {
-		if (self.config.prefix.length > 0) {
-			self.FIELD_URL.label = 'URI'
-		}
-	}
 
 	self.setActions({
 		post: {

--- a/index.js
+++ b/index.js
@@ -57,6 +57,27 @@ instance.prototype.destroy = function () {
 	debug('destroy')
 }
 
+instance.prototype.FIELD_URL = {
+	type: 'textwithvariables',
+	label: urlLabel,
+	id: 'url',
+	default: '',
+}
+
+instance.prototype.FIELD_BODY = {
+	type: 'textwithvariables',
+	label: 'Body(JSON)',
+	id: 'body',
+	default: '{}',
+}
+
+instance.prototype.FIELD_HEADER = {
+	type: 'textwithvariables',
+	label: 'header input(JSON)',
+	id: 'header',
+	default: '',
+}
+
 instance.prototype.actions = function (system) {
 	var self = this
 	var urlLabel = 'URL'
@@ -70,112 +91,23 @@ instance.prototype.actions = function (system) {
 	self.setActions({
 		post: {
 			label: 'POST',
-			options: [
-				{
-					type: 'textwithvariables',
-					label: urlLabel,
-					id: 'url',
-					default: '',
-				},
-				{
-					type: 'textwithvariables',
-					label: 'Body(JSON)',
-					id: 'body',
-					default: '{}',
-				},
-				{
-					type: 'textwithvariables',
-					label: 'header input(JSON)',
-					id: 'header',
-					default: '',
-				},
-			],
+			options: [self.FIELD_URL, self.FIELD_BODY, self.FIELD_HEADER],
 		},
 		get: {
 			label: 'GET',
-			options: [
-				{
-					type: 'textwithvariables',
-					label: urlLabel,
-					id: 'url',
-					default: '',
-				},
-				{
-					type: 'textwithvariables',
-					label: 'header input(JSON)',
-					id: 'header',
-					default: '',
-				},
-			],
+			options: [self.FIELD_URL, self.FIELD_HEADER],
 		},
 		put: {
 			label: 'PUT',
-			options: [
-				{
-					type: 'textwithvariables',
-					label: urlLabel,
-					id: 'url',
-					default: '',
-				},
-				{
-					type: 'textwithvariables',
-					label: 'Body(JSON)',
-					id: 'body',
-					default: '{}',
-				},
-				{
-					type: 'textwithvariables',
-					label: 'header input(JSON)',
-					id: 'header',
-					default: '',
-				},
-			],
+			options: [self.FIELD_URL, self.FIELD_BODY, self.FIELD_HEADER],
 		},
 		patch: {
 			label: 'PATCH',
-			options: [
-				{
-					type: 'textwithvariables',
-					label: urlLabel,
-					id: 'url',
-					default: '',
-				},
-				{
-					type: 'textwithvariables',
-					label: 'Body(JSON)',
-					id: 'body',
-					default: '{}',
-				},
-				{
-					type: 'textwithvariables',
-					label: 'header input(JSON)',
-					id: 'header',
-					default: '',
-				},
-			],
+			options: [self.FIELD_URL, self.FIELD_BODY, self.FIELD_HEADER],
 		},
 		delete: {
 			label: 'DELETE',
-			options: [
-				{
-					type: 'textwithvariables',
-					label: urlLabel,
-					id: 'url',
-					default: '',
-				},
-				{
-					type: 'textwithvariables',
-					label: 'Body(JSON)',
-					id: 'body',
-					default: '{}',
-				},
-				{
-					type: 'textwithvariables',
-					label: 'header input(JSON)',
-					id: 'header',
-					default: '',
-				},
-			],
+			options: [self.FIELD_URL, self.FIELD_BODY, self.FIELD_HEADER],
 		},
 	})
 }

--- a/index.js
+++ b/index.js
@@ -1,342 +1,205 @@
-var instance_skel = require('../../instance_skel');
-var debug;
-var log;
+var instance_skel = require('../../instance_skel')
+var debug
+var log
 
 function instance(system, id, config) {
-	var self = this;
+	var self = this
 
 	// super-constructor
-	instance_skel.apply(this, arguments);
+	instance_skel.apply(this, arguments)
 
-	self.actions(); // export actions
+	self.actions() // export actions
 
-	return self;
+	return self
 }
 
-instance.prototype.updateConfig = function(config) {
-	var self = this;
+instance.prototype.updateConfig = function (config) {
+	var self = this
 
-	self.config = config;
+	self.config = config
 
-	self.actions();
+	self.actions()
 }
 
-instance.prototype.init = function() {
-	var self = this;
+instance.prototype.init = function () {
+	var self = this
 
-	self.status(self.STATE_OK);
+	self.status(self.STATE_OK)
 
-	debug = self.debug;
-	log = self.log;
+	debug = self.debug
+	log = self.log
 }
 
 // Return config fields for web config
 instance.prototype.config_fields = function () {
-	var self = this;
+	var self = this
 	return [
 		{
 			type: 'text',
 			id: 'info',
 			width: 12,
 			label: 'Information',
-			value: '<strong>PLEASE READ THIS!</strong> Generic modules is only for use with custom applications. If you use this module to control a device or software on the market that more than you are using, <strong>PLEASE let us know</strong> about this software, so we can make a proper module for it. If we already support this and you use this to trigger a feature our module doesnt support, please let us know. We want companion to be as easy as possible to use for anyone.<br /><br />Use the \'Base URL\' field below to define a starting URL for the instance\'s commands: e.g. \'http://server.url/path/\'.  <b>This field will be ignored if a command uses a full URL.</b>'
+			value:
+				"<strong>PLEASE READ THIS!</strong> Generic modules is only for use with custom applications. If you use this module to control a device or software on the market that more than you are using, <strong>PLEASE let us know</strong> about this software, so we can make a proper module for it. If we already support this and you use this to trigger a feature our module doesnt support, please let us know. We want companion to be as easy as possible to use for anyone.<br /><br />Use the 'Base URL' field below to define a starting URL for the instance's commands: e.g. 'http://server.url/path/'.  <b>This field will be ignored if a command uses a full URL.</b>",
 		},
 		{
 			type: 'textinput',
 			id: 'prefix',
 			label: 'Base URL',
-			width: 12
-		}
+			width: 12,
+		},
 	]
 }
 
 // When module gets deleted
-instance.prototype.destroy = function() {
-	var self = this;
-	debug("destroy");
+instance.prototype.destroy = function () {
+	var self = this
+	debug('destroy')
 }
 
-instance.prototype.actions = function(system) {
-	var self = this;
-	var urlLabel = 'URL';
+instance.prototype.actions = function (system) {
+	var self = this
+	var urlLabel = 'URL'
 
-	if ( self.config.prefix !== undefined ) {
-		if ( self.config.prefix.length > 0 ) {
-			urlLabel = 'URI';
+	if (self.config.prefix !== undefined) {
+		if (self.config.prefix.length > 0) {
+			urlLabel = 'URI'
 		}
 	}
 
 	self.setActions({
-		'post': {
+		post: {
 			label: 'POST',
 			options: [
 				{
-					type: 'textinput',
+					type: 'textwithvariables',
 					label: urlLabel,
 					id: 'url',
-					default: ''
+					default: '',
 				},
 				{
-					type: 'textinput',
+					type: 'textwithvariables',
 					label: 'Body(JSON)',
 					id: 'body',
-					default: '{}'
+					default: '{}',
 				},
 				{
-					type: 'textinput',
+					type: 'textwithvariables',
 					label: 'header input(JSON)',
 					id: 'header',
 					default: '',
-				}
-			]
+				},
+			],
 		},
-		'get': {
+		get: {
 			label: 'GET',
 			options: [
 				{
-					type: 'textinput',
+					type: 'textwithvariables',
 					label: urlLabel,
 					id: 'url',
 					default: '',
 				},
 				{
-					type: 'textinput',
+					type: 'textwithvariables',
 					label: 'header input(JSON)',
 					id: 'header',
 					default: '',
-				}
-			]
+				},
+			],
 		},
-		'put': {
+		put: {
 			label: 'PUT',
 			options: [
 				{
-					type: 'textinput',
+					type: 'textwithvariables',
 					label: urlLabel,
 					id: 'url',
-					default: ''
+					default: '',
 				},
 				{
-					type: 'textinput',
+					type: 'textwithvariables',
 					label: 'Body(JSON)',
 					id: 'body',
-					default: '{}'
+					default: '{}',
 				},
 				{
-					type: 'textinput',
+					type: 'textwithvariables',
 					label: 'header input(JSON)',
 					id: 'header',
 					default: '',
-				}
-			]
+				},
+			],
 		},
-	});
+	})
 }
 
-instance.prototype.action = function(action) {
-	var self = this;
-	var cmd;
+instance.prototype.action = function (action) {
+	var self = this
+	var cmd = ''
+	var body = {}
+	var header = {}
+	var restCmds = {
+		post: 'rest',
+		get: 'rest_get',
+		put: 'rest_put',
+		patch: 'rest_patch',
+		delete: 'rest_delete',
+	}
+	var restCmd = restCmds[action.action]
+	var errorHandler = function (err, result) {
+		if (err !== null) {
+			self.log('error', `HTTP ${action.action.toUpperCase()} Request failed (${e.message})`)
+			self.status(self.STATUS_ERROR, result.error.code)
+		} else {
+			self.status(self.STATUS_OK)
+		}
+	}
 
-	if ( self.config.prefix !== undefined && action.options.url.substring(0,4) != 'http' ) {
-		if ( self.config.prefix.length > 0 ) {
-			cmd = self.config.prefix + action.options.url;
+	self.system.emit('variable_parse', action.options.url, function (value) {
+		cmd = value
+	})
+
+	if (action.options.url.substring(0, 4) !== 'http') {
+		if (self.config.prefix.length > 0) {
+			cmd = `${self.config.prefix}${cmd.trim()}`
 		}
-		else {
-			cmd = action.options.url;
-		}
-	}
-	else {
-		cmd = action.options.url;
 	}
 
-	if (action.action == 'post') {
-		var body;
-		var header;
+	if (action.options.body.trim() !== '') {
+		self.system.emit('variable_parse', action.options.body, function (value) {
+			body = value
+		})
+
 		try {
-			body = JSON.parse(action.options.body);
-		} catch(e){
-			self.log('error', 'HTTP POST Request aborted: Malformed JSON Body (' + e.message+ ')');
-			self.status(self.STATUS_ERROR, e.message);
+			body = JSON.parse(body)
+		} catch (e) {
+			self.log('error', `HTTP ${action.action.toUpperCase()} Request aborted: Malformed JSON Body (${e.message})`)
+			self.status(self.STATUS_ERROR, e.message)
 			return
 		}
-		if(!!action.options.header) {
-			try {
-				header = JSON.parse(action.options.header);
-			} catch(e){
-				self.log('error', 'HTTP POST Request aborted: Malformed JSON header (' + e.message+ ')');
-				self.status(self.STATUS_ERROR, e.message);
-				return
-			}
-			self.system.emit('rest', cmd, body, function (err, result) {
-				if (err !== null) {
-					self.log('error', 'HTTP POST Request failed (' + result.error.code + ')');
-					self.status(self.STATUS_ERROR, result.error.code);
-				}
-				else {
-					self.status(self.STATUS_OK);
-				}
-			}, header);
-		} else {
-			self.system.emit('rest', cmd, body, function (err, result) {
-				if (err !== null) {
-					self.log('error', 'HTTP POST Request failed (' + result.error.code + ')');
-					self.status(self.STATUS_ERROR, result.error.code);
-				}
-				else {
-					self.status(self.STATUS_OK);
-				}
-			});
-		}
 	}
-	else if (action.action == 'get') {
-		var header;
-		if(!!action.options.header) {
-			try {
-				header = JSON.parse(action.options.header);
-			} catch(e){
-				self.log('error', 'HTTP GET Request aborted: Malformed JSON header (' + e.message+ ')');
-				self.status(self.STATUS_ERROR, e.message);
-				return
-			}
-			self.system.emit('rest_get', cmd, function (err, result) {
-				if (err !== null) {
-					self.log('error', 'HTTP GET Request failed (' + result.error.code + ')');
-					self.status(self.STATUS_ERROR, result.error.code);
-				}
-				else {
-					self.status(self.STATUS_OK);
-				}
-			}, header);
-		} else {
-			self.system.emit('rest_get', cmd, function (err, result) {
-				if (err !== null) {
-					self.log('error', 'HTTP GET Request failed (' + result.error.code + ')');
-					self.status(self.STATUS_ERROR, result.error.code);
-				}
-				else {
-					self.status(self.STATUS_OK);
-				}
-			});
-		}
-	}
-	else if (action.action == 'put') {
-		var body;
-		var header;
+
+	if (action.options.header.trim() !== '') {
+		self.system.emit('variable_parse', action.options.header, function (value) {
+			header = value
+		})
+
 		try {
-			body = JSON.parse(action.options.body);
-		} catch(e){
-			self.log('error', 'HTTP PUT Request aborted: Malformed JSON Body (' + e.message+ ')');
-			self.status(self.STATUS_ERROR, e.message);
+			header = JSON.parse(header)
+		} catch (e) {
+			self.log('error', `HTTP ${action.action.toUpperCase()} Request aborted: Malformed JSON Header (${e.message})`)
+			self.status(self.STATUS_ERROR, e.message)
 			return
 		}
-		if(!!action.options.header) {
-			try {
-				header = JSON.parse(action.options.header);
-			} catch(e){
-				self.log('error', 'HTTP PUT Request aborted: Malformed JSON header (' + e.message+ ')');
-				self.status(self.STATUS_ERROR, e.message);
-				return
-			}
-			self.system.emit('rest_put', cmd, body, function (err, result) {
-				if (err !== null) {
-					self.log('error', 'HTTP PUT Request failed (' + result.error.code + ')');
-					self.status(self.STATUS_ERROR, result.error.code);
-				}
-				else {
-					self.status(self.STATUS_OK);
-				}
-			}, header);
-		} else {
-			self.system.emit('rest_put', cmd, body, function (err, result) {
-				if (err !== null) {
-					self.log('error', 'HTTP PUT Request failed (' + result.error.code + ')');
-					self.status(self.STATUS_ERROR, result.error.code);
-				}
-				else {
-					self.status(self.STATUS_OK);
-				}
-			});
-		}
 	}
-	else if (action.action == 'patch') {
-		var body;
-		var header;
-		try {
-			body = JSON.parse(action.options.body);
-		} catch(e){
-			self.log('error', 'HTTP PATCH Request aborted: Malformed JSON Body (' + e.message+ ')');
-			self.status(self.STATUS_ERROR, e.message);
-			return
-		}
-		if(!!action.options.header) {
-			try {
-				header = JSON.parse(action.options.header);
-			} catch(e){
-				self.log('error', 'HTTP PATCH Request aborted: Malformed JSON header (' + e.message+ ')');
-				self.status(self.STATUS_ERROR, e.message);
-				return
-			}
-			self.system.emit('rest_patch', cmd, body, function (err, result) {
-				if (err !== null) {
-					self.log('error', 'HTTP PATCH Request failed (' + result.error.code + ')');
-					self.status(self.STATUS_ERROR, result.error.code);
-				}
-				else {
-					self.status(self.STATUS_OK);
-				}
-			}, header);
-		} else {
-			self.system.emit('rest_patch', cmd, body, function (err, result) {
-				if (err !== null) {
-					self.log('error', 'HTTP PATCH Request failed (' + result.error.code + ')');
-					self.status(self.STATUS_ERROR, result.error.code);
-				}
-				else {
-					self.status(self.STATUS_OK);
-				}
-			});
-		}
-	}
-	else if (action.action == 'delete') {
-		var body;
-		var header;
-		try {
-			body = JSON.parse(action.options.body);
-		} catch(e){
-			self.log('error', 'HTTP DELETE Request aborted: Malformed JSON Body (' + e.message+ ')');
-			self.status(self.STATUS_ERROR, e.message);
-			return
-		}
-		if(!!action.options.header) {
-			try {
-				header = JSON.parse(action.options.header);
-			} catch(e){
-				self.log('error', 'HTTP DELETE Request aborted: Malformed JSON header (' + e.message+ ')');
-				self.status(self.STATUS_ERROR, e.message);
-				return
-			}
-			self.system.emit('rest_delete', cmd, body, function (err, result) {
-				if (err !== null) {
-					self.log('error', 'HTTP DELETE Request failed (' + result.error.code + ')');
-					self.status(self.STATUS_ERROR, result.error.code);
-				}
-				else {
-					self.status(self.STATUS_OK);
-				}
-			}, header);
-		} else {
-			self.system.emit('rest_delete', cmd, body, function (err, result) {
-				if (err !== null) {
-					self.log('error', 'HTTP DELETE Request failed (' + result.error.code + ')');
-					self.status(self.STATUS_ERROR, result.error.code);
-				}
-				else {
-					self.status(self.STATUS_OK);
-				}
-			});
-		}
+
+	if (cmd === 'rest_get') {
+		self.system.emit(restCmd, cmd, errorHandler, header)
+	} else {
+		self.system.emit(restCmd, cmd, body, errorHandler, header)
 	}
 }
 
-instance_skel.extendedBy(instance);
-exports = module.exports = instance;
+instance_skel.extendedBy(instance)
+exports = module.exports = instance

--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ instance.prototype.destroy = function () {
 
 instance.prototype.FIELD_URL = {
 	type: 'textwithvariables',
-	label: urlLabel,
+	label: 'URL',
 	id: 'url',
 	default: '',
 }
@@ -80,11 +80,10 @@ instance.prototype.FIELD_HEADER = {
 
 instance.prototype.actions = function (system) {
 	var self = this
-	var urlLabel = 'URL'
 
 	if (self.config.prefix !== undefined) {
 		if (self.config.prefix.length > 0) {
-			urlLabel = 'URI'
+			self.FIELD_URL.label = 'URI'
 		}
 	}
 

--- a/index.js
+++ b/index.js
@@ -131,6 +131,52 @@ instance.prototype.actions = function (system) {
 				},
 			],
 		},
+		patch: {
+			label: 'PATCH',
+			options: [
+				{
+					type: 'textwithvariables',
+					label: urlLabel,
+					id: 'url',
+					default: '',
+				},
+				{
+					type: 'textwithvariables',
+					label: 'Body(JSON)',
+					id: 'body',
+					default: '{}',
+				},
+				{
+					type: 'textwithvariables',
+					label: 'header input(JSON)',
+					id: 'header',
+					default: '',
+				},
+			],
+		},
+		delete: {
+			label: 'DELETE',
+			options: [
+				{
+					type: 'textwithvariables',
+					label: urlLabel,
+					id: 'url',
+					default: '',
+				},
+				{
+					type: 'textwithvariables',
+					label: 'Body(JSON)',
+					id: 'body',
+					default: '{}',
+				},
+				{
+					type: 'textwithvariables',
+					label: 'header input(JSON)',
+					id: 'header',
+					default: '',
+				},
+			],
+		},
 	})
 }
 


### PR DESCRIPTION
Enable the `http: GET`, `http: PUT` and `http: POST` actions to accept
custom variables within the `URI`, `Body(JSON)` and `header input(JSON)`
options.

I've also refactored/simplified the instance `action` method.

Usage example:
![image](https://user-images.githubusercontent.com/5514878/140846611-113a4ad7-ca81-4f69-9c87-fcfa7b23edc8.png)


Resolves #12
Signed-off-by: Johnny Estilles <johnny@estilles.com>