### PR TITLE
fix(actions): ignore missing body on GET action

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,7 +149,7 @@ instance.prototype.action = function (action) {
 		}
 	}
 
-	if (action.options.body.trim() !== '') {
+	if (action.options.body && action.options.body.trim() !== '') {
 		self.system.emit('variable_parse', action.options.body, function (value) {
 			body = value
 		})
@@ -177,6 +177,7 @@ instance.prototype.action = function (action) {
 		}
 	}
 
+	console.log({restCmd, cmd, body, header}) 
 	if (restCmd === 'rest_get') {
 		self.system.emit(restCmd, cmd, errorHandler, header)
 	} else {

--- a/index.js
+++ b/index.js
@@ -177,7 +177,6 @@ instance.prototype.action = function (action) {
 		}
 	}
 
-	console.log({restCmd, cmd, body, header}) 
 	if (restCmd === 'rest_get') {
 		self.system.emit(restCmd, cmd, errorHandler, header)
 	} else {


### PR DESCRIPTION
Fixing "Cannot read property 'trim' of undefined" on GET action

Resolves #16

Signed-off-by: Johnny Estilles <johnny@estilles.com>