### PR TITLE
fix(instance): add missing upgrade script

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,26 @@ function instance(system, id, config) {
 	return self
 }
 
+instance.GetUpgradeScripts = function () {
+	return [
+		function v1_1_4(context, config, actions) {
+			let updated = false
+
+			actions.forEach((action) => {
+				// set default content-type on older actions
+				if (['post', 'put', 'patch'].includes(action.action)) {
+					if (action.options.contenttype === undefined) {
+						action.options.contenttype = 'application/json'
+						updated = true
+					}
+				}
+			})
+
+			return updated
+		},
+	]
+}
+
 instance.prototype.updateConfig = function (config) {
 	var self = this
 


### PR DESCRIPTION
We should've added an upgrade script on PR #18 to update existing actions with a default value for the new `contenttype` option.

Signed-off-by: Johnny Estilles <johnny@estilles.com>