### PR TITLE
Add the ability to set custom variable values with an HTTP request

### DIFF
--- a/index.js
+++ b/index.js
@@ -209,7 +209,7 @@ class instance extends instance_skel {
 
 		let options = {
 			connection: {
-				rejectUnauthorized: self.config.rejectUnauthorized,
+				rejectUnauthorized: this.config.rejectUnauthorized,
 			},
 		}
 


### PR DESCRIPTION
As requested on: https://app.bountysource.com/issues/105114232-add-the-ability-ability-to-set-custom-variable-values-with-an-http-request
fixes #24 