### PR TITLE
json result data to custom var

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
 	"bugs": {
 		"url": "https://github.com/bitfocus/companion-module-generic-http/issues"
 	},
-	"homepage": "https://github.com/bitfocus/companion-module-generic-http#readme"
+	"homepage": "https://github.com/bitfocus/companion-module-generic-http#readme",
+	"dependencies": {
+		"jsonpath": "^1.1.1"
+	}
 }


### PR DESCRIPTION
fixes #24, re #27

For more information please refer to #27

## Testing

```sh
# within companion source folder

cd module-custom-dev
git clone https://github.com/abebeos/companion-module-generic-http.git
cd companion-module-generic-http
git checkout feat/i24-json-result-to-var
cd ..

yarn dev
```

Following screenshots show the get-request and the setvar on 2 buttons (this can be done with 1 button, too, adding 2 actions and possibly some delay)

![image](https://user-images.githubusercontent.com/84547391/154254759-916f3940-bb3f-4d78-940e-820ee2574e0c.png)


![image](https://user-images.githubusercontent.com/84547391/154253930-8ab47f68-97ac-4022-b481-15c8a708cc07.png)


![image](https://user-images.githubusercontent.com/84547391/154254266-197389c9-5c23-4da7-9120-d781531d214f.png)

![image](https://user-images.githubusercontent.com/84547391/154254994-86e27d2c-f85d-4436-9cd1-7235ab57826d.png)



![image](https://user-images.githubusercontent.com/84547391/154254501-4b63e0b9-69bb-40b4-82d8-490f27b7aad0.png)

![image](https://user-images.githubusercontent.com/84547391/154255215-68c71d9a-6991-4d8f-acc5-d4bbd9cd0885.png)

