### PR TITLE
remove getvar functionality

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 const instance_skel = require('../../instance_skel')
 let debug = () => {}
 let log
-var jp = require('jsonpath');
 
 class instance extends instance_skel {
 	/**
@@ -174,13 +173,6 @@ class instance extends instance_skel {
 		],
 	}
 
-	FIELD_JSON_PATH = {
-		type: 'textwithvariables',
-		label: 'Path (like $.age)',
-		id: 'jsonPath',
-		default: '',
-	}
-
 	FIELD_JSON_DATA_VARIABLE = null
 
 	actions(system) {
@@ -195,19 +187,7 @@ class instance extends instance_skel {
 				label: id,
 			})),
 		}
-		this.FIELD_JSON_DATA_VARIABLE.choices.unshift({id:'', label:'<NONE>'})
-
-        this.FIELD_TARGET_VARIABLE = {
-			type: 'dropdown',
-			label: 'Target Variable',
-			id: 'targetVariable',
-			default: '',
-			choices: Object.entries(this.customVariables).map(([id, info]) => ({
-				id: id,
-				label: id,
-			})),
-		}
-		this.FIELD_TARGET_VARIABLE.choices.unshift({id:'', label:'<NONE>'})				
+		this.FIELD_JSON_DATA_VARIABLE.choices.unshift({id:'', label:'<NONE>'})	
 
 		this.setActions({
 			post: {
@@ -229,10 +209,6 @@ class instance extends instance_skel {
 			delete: {
 				label: 'DELETE',
 				options: [this.FIELD_URL, this.FIELD_BODY, this.FIELD_HEADER],
-			},
-			setvar: {
-				label: 'SETVAR',
-				options: [this.FIELD_JSON_DATA_VARIABLE, this.FIELD_JSON_PATH, this.FIELD_TARGET_VARIABLE],
 			},
 		})
 	}
@@ -278,46 +254,7 @@ class instance extends instance_skel {
 			connection: {
 				rejectUnauthorized: this.config.rejectUnauthorized,
 			},
-		}
-
-		//TODO: consider moving the setvar-action to companion-module-bitfocus-companion
-
-		// extract value from the stored json response data, assign to target variable		
-		if (action.action === 'setvar') {
-
-			// get the json response data from the custom variable that holds the data
-			let jsonResultData = ''
-			let variableName = `custom_${action.options.jsonResultDataVariable}`
-			this.system.emit('variable_get', 'internal', variableName, (value) => {
-				jsonResultData = value
-				debug('jsonResultData', jsonResultData)				
-			})
-
-			// recreate a json object from stored json result data string
-			let objJson = ''
-			try {
-				objJson = JSON.parse(jsonResultData)
-			} catch (e) {
-				this.log('error', `HTTP ${action.action.toUpperCase()} Cannot create JSON object, malformed JSON data (${e.message})`)
-				this.status(self.STATUS_ERROR, e.message)
-				return
-			}
-
-			// extract the value via the given standard JSONPath expression
-			let valueToSet = ''
-			try {
-				valueToSet = jp.query(objJson, action.options.jsonPath)
-			} catch (error) {
-				this.log('error', `HTTP ${action.action.toUpperCase()} Cannot extract JSON value (${e.message})`)
-				this.status(this.STATUS_ERROR, error.message)
-				return		
-			}
-
-			this.system.emit('custom_variable_set_value', action.options.targetVariable, valueToSet)			
-
-			this.status(this.STATUS_OK)
-			return
-		}		
+		}	
 
 		this.system.emit('variable_parse', action.options.url, (value) => {
 			cmd = value

--- a/package.json
+++ b/package.json
@@ -27,8 +27,5 @@
 	"bugs": {
 		"url": "https://github.com/bitfocus/companion-module-generic-http/issues"
 	},
-	"homepage": "https://github.com/bitfocus/companion-module-generic-http#readme",
-	"dependencies": {
-		"jsonpath": "^1.1.1"
-	}
+	"homepage": "https://github.com/bitfocus/companion-module-generic-http#readme"
 }


### PR DESCRIPTION
re https://github.com/bitfocus/companion-module-generic-http/pull/28

getvar was moved to https://github.com/bitfocus/companion-module-bitfocus-companion/pull/50 (`custom_variable_set_via_jsonpath`), thus it can be removed now from generic-http to keep it clean.