### PR TITLE
feat: Add proxy support

### DIFF
--- a/config.js
+++ b/config.js
@@ -16,6 +16,21 @@ export const configFields = [
 	},
 	{
 		type: 'static-text',
+		id: 'proxies',
+		width: 12,
+		label: 'Proxies',
+		value:
+			"Enter proxy config below",
+	},
+	{
+		type: 'textinput',
+		id: 'proxyAddress',
+		label: 'Proxy Address',
+		width: 12,
+		default: '',
+	},
+	{
+		type: 'static-text',
 		id: 'rejectUnauthorizedInfo',
 		width: 12,
 		value: `

--- a/config.js
+++ b/config.js
@@ -15,17 +15,10 @@ export const configFields = [
 		default: '',
 	},
 	{
-		type: 'static-text',
-		id: 'proxies',
-		width: 12,
-		label: 'Proxies',
-		value:
-			"Enter proxy config below",
-	},
-	{
 		type: 'textinput',
 		id: 'proxyAddress',
 		label: 'Proxy Address',
+		tooltip: 'E.g. http://username:password@proxy-server:8080',
 		width: 12,
 		default: '',
 	},

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 import { InstanceBase, runEntrypoint, InstanceStatus } from '@companion-module/base'
 import got from 'got'
+import { HttpProxyAgent, HttpsProxyAgent } from 'hpagent'
 import { configFields } from './config.js'
 import { upgradeScripts } from './upgrade.js'
 import { FIELDS } from './fields.js'
@@ -93,6 +94,17 @@ class GenericHttpInstance extends InstanceBase {
 				options.body = body
 			} else if (body) {
 				options.json = body
+			}
+		}
+
+		if(this.config.proxyAddress && this.config.proxyAddress.length > 0) {
+			options.agent = {
+				http: new HttpProxyAgent({
+					proxy: this.config.proxyAddress
+				}),
+				https: new HttpsProxyAgent({
+					proxy: this.config.proxyAddress
+				})
 			}
 		}
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 	"dependencies": {
 		"@companion-module/base": "~1.10.0",
 		"got": "^13.0.0",
+		"hpagent": "^1.2.0",
 		"jimp": "^0.22.12"
 	},
 	"devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1974,6 +1974,7 @@ __metadata:
     "@companion-module/base": "npm:~1.10.0"
     "@companion-module/tools": "npm:^1.5.1"
     got: "npm:^13.0.0"
+    hpagent: "npm:^1.2.0"
     jimp: "npm:^0.22.12"
   languageName: unknown
   linkType: soft
@@ -2135,6 +2136,13 @@ __metadata:
   dependencies:
     function-bind: "npm:^1.1.2"
   checksum: 10c0/5d415b114f410661208c95e7ab4879f1cc2765b8daceff4dc8718317d1cb7b9ffa7c5d1eafd9a4389c9aab7445d6ea88e05f3096cb1e529618b55304956b87fc
+  languageName: node
+  linkType: hard
+
+"hpagent@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "hpagent@npm:1.2.0"
+  checksum: 10c0/505ef42e5e067dba701ea21e7df9fa73f6f5080e59d53680829827d34cd7040f1ecf7c3c8391abe9df4eb4682ef4a4321608836b5b70a61b88c1b3a03d77510b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This adds http/https proxy support the generic-http module.

The config is set at the connection level.

If you want some connections to be direct and some via a proxy you can create two generic-http connections.

This resolves https://github.com/bitfocus/companion-module-generic-http/issues/59