### PR TITLE
Fix/allow falsey json body

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,7 +133,6 @@ class GenericHttpInstance extends InstanceBase {
 		}
 
 		if (includeBody) {
-			
 			if (typeof body === 'string') {
 				body = body.replace(/\\n/g, '\n')
 				options.body = body

--- a/index.js
+++ b/index.js
@@ -45,31 +45,78 @@ class GenericHttpInstance extends InstanceBase {
 		}
 
 		let body = {}
-		if (includeBody && action.options.body && action.options.body.trim() !== '') {
-			body = await context.parseVariablesInString(action.options.body || '')
-
-			if (action.options.contenttype === 'application/json') {
-				//only parse the body if we are explicitly sending application/json
+		if (includeBody && action.options.body !== undefined && action.options.body !== null) {
+			// Handle the body value - it could be a string, boolean, number, etc.
+			let bodyValue = action.options.body
+			
+			// If it's a string, parse variables and check if it's empty
+			if (typeof bodyValue === 'string') {
+				bodyValue = await context.parseVariablesInString(bodyValue || '')
+				if (bodyValue.trim() === '') {
+					bodyValue = undefined
+				}
+			} else {
 				try {
-					body = JSON.parse(body)
+					bodyValue = await context.parseVariablesInString(bodyValue)
 				} catch (e) {
-					this.log('error', `HTTP ${action.actionId.toUpperCase()} Request aborted: Malformed JSON Body (${e.message})`)
-					this.updateStatus(InstanceStatus.UnknownError, e.message)
-					return
+					// If parsing fails, use the original value
+					bodyValue = action.options.body
+				}
+			}
+
+			if (bodyValue !== undefined && bodyValue !== null) {
+				
+				if (action.options.contenttype === 'application/json') {
+					// For JSON content type, handle different input types
+					if (typeof bodyValue === 'string') {
+						// If it's a string, try to parse it as JSON
+						try {
+							body = JSON.parse(bodyValue)
+						} catch (e) {
+							this.log('error', `HTTP ${action.actionId.toUpperCase()} Request aborted: Malformed JSON Body (${e.message})`)
+							this.updateStatus(InstanceStatus.UnknownError, e.message)
+							return
+						}
+					} else {
+						// If it's already a non-string value (boolean, number, object, array), use it directly
+						body = bodyValue
+					}
+				} else {
+					// For non-JSON content types, convert to string
+					body = String(bodyValue)
 				}
 			}
 		}
 
 		let headers = {}
-		if (action.options.header.trim() !== '') {
-			const headersStr = await context.parseVariablesInString(action.options.header || '')
+		if (action.options.header !== undefined && action.options.header !== null) {
+			// Handle the header value - it could be a string, boolean, number, etc.
+			let headerValue = action.options.header
+			
+			// If it's a string, parse variables and check if it's empty
+			if (typeof headerValue === 'string') {
+				headerValue = await context.parseVariablesInString(headerValue || '')
+				if (headerValue.trim() === '') {
+					headerValue = undefined
+				}
+			} else {
+				// For non-string values, parse variables if possible
+				try {
+					headerValue = await context.parseVariablesInString(headerValue)
+				} catch (e) {
+					// If parsing fails, use the original value
+					headerValue = action.options.header
+				}
+			}
 
-			try {
-				headers = JSON.parse(headersStr)
-			} catch (e) {
-				this.log('error', `HTTP ${action.actionId.toUpperCase()} Request aborted: Malformed JSON Header (${e.message})`)
-				this.updateStatus(InstanceStatus.UnknownError, e.message)
-				return
+			if (headerValue !== undefined && headerValue !== null) {
+				try {
+					headers = JSON.parse(headerValue)
+				} catch (e) {
+					this.log('error', `HTTP ${action.actionId.toUpperCase()} Request aborted: Malformed JSON Header (${e.message})`)
+					this.updateStatus(InstanceStatus.UnknownError, e.message)
+					return
+				}
 			}
 		}
 
@@ -86,11 +133,16 @@ class GenericHttpInstance extends InstanceBase {
 		}
 
 		if (includeBody) {
+			
 			if (typeof body === 'string') {
 				body = body.replace(/\\n/g, '\n')
 				options.body = body
-			} else if (body) {
-				options.json = body
+			} else if (body !== undefined && body !== null) {
+				if (action.options.contenttype === 'application/json') {
+					options.json = body
+				} else {
+					options.body = String(body)
+				}
 			}
 		}
 
@@ -150,7 +202,11 @@ class GenericHttpInstance extends InstanceBase {
 					const { url, options } = await this.prepareQuery(context, action, true)
 
 					try {
-						const response = await got.post(url, options)
+						const response = await got.post(url, {...options, hooks: {beforeRequest: [
+							(options) => {
+								console.log('=BEFORE REQUEST=', options)
+							}
+						]}})
 
 						this.processResponse(action, response)
 

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ class GenericHttpInstance extends InstanceBase {
 		if (includeBody && action.options.body !== undefined && action.options.body !== null) {
 			// Handle the body value - it could be a string, boolean, number, etc.
 			let bodyValue = action.options.body
-			
+
 			// If it's a string, parse variables and check if it's empty
 			if (typeof bodyValue === 'string') {
 				bodyValue = await context.parseVariablesInString(bodyValue || '')
@@ -65,7 +65,7 @@ class GenericHttpInstance extends InstanceBase {
 			}
 
 			if (bodyValue !== undefined && bodyValue !== null) {
-				
+
 				if (action.options.contenttype === 'application/json') {
 					// For JSON content type, handle different input types
 					if (typeof bodyValue === 'string') {
@@ -92,7 +92,7 @@ class GenericHttpInstance extends InstanceBase {
 		if (action.options.header !== undefined && action.options.header !== null) {
 			// Handle the header value - it could be a string, boolean, number, etc.
 			let headerValue = action.options.header
-			
+
 			// If it's a string, parse variables and check if it's empty
 			if (typeof headerValue === 'string') {
 				headerValue = await context.parseVariablesInString(headerValue || '')
@@ -133,6 +133,7 @@ class GenericHttpInstance extends InstanceBase {
 		}
 
 		if (includeBody) {
+
 			if (typeof body === 'string') {
 				body = body.replace(/\\n/g, '\n')
 				options.body = body
@@ -145,7 +146,7 @@ class GenericHttpInstance extends InstanceBase {
 			}
 		}
 
-		if(this.config.proxyAddress && this.config.proxyAddress.length > 0) {
+		if (this.config.proxyAddress && this.config.proxyAddress.length > 0) {
 			options.agent = {
 				http: new HttpProxyAgent({
 					proxy: this.config.proxyAddress
@@ -191,21 +192,17 @@ class GenericHttpInstance extends InstanceBase {
 			post: {
 				name: 'POST',
 				options: [FIELDS.Url(urlLabel),
-					  FIELDS.Body,
-					  FIELDS.Header,
-					  FIELDS.ContentType,
-					  FIELDS.JsonResponseVariable,
-					  FIELDS.JsonStringify,
+				FIELDS.Body,
+				FIELDS.Header,
+				FIELDS.ContentType,
+				FIELDS.JsonResponseVariable,
+				FIELDS.JsonStringify,
 				],
 				callback: async (action, context) => {
 					const { url, options } = await this.prepareQuery(context, action, true)
 
 					try {
-						const response = await got.post(url, {...options, hooks: {beforeRequest: [
-							(options) => {
-								console.log('=BEFORE REQUEST=', options)
-							}
-						]}})
+						const response = await got.post(url, options)
 
 						this.processResponse(action, response)
 
@@ -219,9 +216,9 @@ class GenericHttpInstance extends InstanceBase {
 			get: {
 				name: 'GET',
 				options: [FIELDS.Url(urlLabel),
-					  FIELDS.Header,
-					  FIELDS.JsonResponseVariable,
-					  FIELDS.JsonStringify,
+				FIELDS.Header,
+				FIELDS.JsonResponseVariable,
+				FIELDS.JsonStringify,
 				],
 				callback: async (action, context) => {
 					const { url, options } = await this.prepareQuery(context, action, false)
@@ -241,11 +238,11 @@ class GenericHttpInstance extends InstanceBase {
 			put: {
 				name: 'PUT',
 				options: [FIELDS.Url(urlLabel),
-					  FIELDS.Body,
-					  FIELDS.Header,
-					  FIELDS.ContentType,
-					  FIELDS.JsonResponseVariable,
-					  FIELDS.JsonStringify,
+				FIELDS.Body,
+				FIELDS.Header,
+				FIELDS.ContentType,
+				FIELDS.JsonResponseVariable,
+				FIELDS.JsonStringify,
 				],
 				callback: async (action, context) => {
 					const { url, options } = await this.prepareQuery(context, action, true)
@@ -265,11 +262,11 @@ class GenericHttpInstance extends InstanceBase {
 			patch: {
 				name: 'PATCH',
 				options: [FIELDS.Url(urlLabel),
-					  FIELDS.Body,
-					  FIELDS.Header,
-					  FIELDS.ContentType,
-					  FIELDS.JsonResponseVariable,
-					  FIELDS.JsonStringify,
+				FIELDS.Body,
+				FIELDS.Header,
+				FIELDS.ContentType,
+				FIELDS.JsonResponseVariable,
+				FIELDS.JsonStringify,
 				],
 				callback: async (action, context) => {
 					const { url, options } = await this.prepareQuery(context, action, true)
@@ -289,10 +286,10 @@ class GenericHttpInstance extends InstanceBase {
 			delete: {
 				name: 'DELETE',
 				options: [FIELDS.Url(urlLabel),
-					  FIELDS.Body,
-					  FIELDS.Header,
-					  FIELDS.JsonResponseVariable,
-					  FIELDS.JsonStringify,
+				FIELDS.Body,
+				FIELDS.Header,
+				FIELDS.JsonResponseVariable,
+				FIELDS.JsonStringify,
 				],
 
 				callback: async (action, context) => {


### PR DESCRIPTION
## Problem
HTTP POST requests with `application/json` content type were failing when the body contained falsey values like `false` or `0`. The issue was caused by:

1. **Type checking error**: The code was calling `.trim()` on non-string values (boolean `false`, number `0`)
2. **Incomplete falsey value handling**: The original logic only checked for empty strings but didn't properly handle boolean `false`, number `0`, or other falsey values
3. **Inconsistent body processing**: Different body types weren't handled uniformly across string and non-string inputs

## Solution
Updated the `prepareQuery` method in `index.js` to properly handle all body value types:

### Key Changes:
1. **Fixed type checking**: Replaced `action.options.body.trim() !== ''` with proper type checking using `typeof bodyValue === 'string'`
2. **Enhanced falsey value support**: Added comprehensive handling for boolean, number, object, and array body values
3. **Improved JSON processing**: For `application/json` content type:
   - String values are parsed as JSON (e.g., `"false"` → `false`)
   - Non-string values (boolean `false`, number `0`) are used direct


## Impact
- **Fixes**: HTTP POST requests with falsey body values now work correctly


## Related Issues
Fixes the problem where users couldn't send `false` or `0` values in HTTP POST requests with `application/json` content type.